### PR TITLE
Change flatpack to flatpak

### DIFF
--- a/peazip-linux-arm.html
+++ b/peazip-linux-arm.html
@@ -167,7 +167,7 @@ EXPERIMENTAL, provided by third parties</span><br>
             <small style="font-weight: bold;"><a
  style="color: rgb(253, 253, 253);" target="_blank"
  href="https://flathub.org/apps/details/io.github.peazip.PeaZip"><big><big><img
- title="PeaZip Flatpack for Linux on ARM" alt="peazip aarch64 flatpack"
+ title="PeaZip Flatpak for Linux on ARM" alt="peazip aarch64 flatpak"
  src="free-rar/download-free-software.png"
  style="border: 0px solid ; width: 15px; height: 9px;">Flatpak</big></big></a></small><br>
             <small>FlatHub's Flatpak packages</small><small></small><small

--- a/peazip-linux.html
+++ b/peazip-linux.html
@@ -214,12 +214,12 @@ require installation, <span style="font-weight: bold;">simply
 de-compress and start the application clicking on peazip</span> binary.</small><br>
             <small> </small><br>
             <big> </big><a style="color: rgb(253, 253, 253);"
- href="#peazip_flatpack"><big style="font-weight: bold;">Alternative
+ href="#peazip_flatpak"><big style="font-weight: bold;">Alternative
 downloads for
 Linux</big></a><br>
             <small>Flatpak and distribution-specific packages</small><br>
             <a style="color: rgb(253, 253, 253);"
- href="#peazip_flatpack"> </a> </div>
+ href="#peazip_flatpak"> </a> </div>
             </td>
           </tr>
         </tbody>
@@ -392,7 +392,7 @@ actively recommended.<br>
  style="border: 0px solid ; width: 795px; height: 508px;"></a></h2>
             <br>
             <br>
-            <big><big><big><a name="peazip_flatpack"></a>Alternative
+            <big><big><big><a name="peazip_flatpak"></a>Alternative
 downloads for Linux</big></big></big>
             <ul>
               <li style="font-weight: bold;"><a
@@ -412,7 +412,7 @@ DEB and RPM packages</a> for PeaZip<br>
             </ul>
             <ul>
               <li style="font-weight: bold;">FlatHub <a
- href="https://flathub.org/apps/details/io.github.peazip.PeaZip">Flatpack<img
+ href="https://flathub.org/apps/details/io.github.peazip.PeaZip">Flatpak<img
  alt="opensuse software packages" src="free-rar/extractor.png"
  style="border: 0px solid ; height: 10px; width: 12px;"></a></li>
             </ul>
@@ -677,7 +677,7 @@ an Open Source alternative app.<br>
 of PeaZip for Linux x86_64 / amd64. Cross platform Free Software
 archive manager application. Open Source WinRar WinZip alternative for
 Linux systems. Desktop neutral archive manager. </span><span
- style="font-weight: bold;">Download PeaZip DEB, Flatpack, RPM,
+ style="font-weight: bold;">Download PeaZip DEB, Flatpak, RPM,
 portable packages. </span><span style="font-weight: bold;">GTK and Qt
 PeaZip builds.<br>
             </span></p>

--- a/peazip-sources.html
+++ b/peazip-sources.html
@@ -448,7 +448,7 @@ peazip-setup_script_WIN*-configure.iss in (peazip)/res/bin directory</li>
 pages for Linux, macOS, and Windows, can provide examples of
 packages for a wide array of different installer technologies and for
 many different package management systems, such as Windows EXE, MSI,
-and MSIX installers, macOS DMG, Linux DEB, RPM, and Flatpack - Flatpack
+and MSIX installers, macOS DMG, Linux DEB, RPM, and Flatpak - Flatpak
 packages are maintained by third parties developers at FlatHub.<br>
             <br>
 At its core, PeaZip is simply a standalone, as autocontained as


### PR DESCRIPTION
Corrects typo flatpack. The technology is called flatpak.