### PR TITLE
download links fixed for `peazip-64bit.html`

### DIFF
--- a/peazip-64bit.html
+++ b/peazip-64bit.html
@@ -155,7 +155,7 @@ bit</span></small><small><span style="color: rgb(253, 253, 253);"><br>
             <td
  style="text-align: center; vertical-align: middle; width: 34%; color: rgb(240, 240, 240);"><br>
             <h3><a target="_blank"
- href="https://github.com/peazip/PeaZip/releases/download/9.0.0/peazip-9.0.0.WIN64.exe"><img
+ href="https://github.com/peazip/PeaZip/releases/download/9.9.0/peazip-9.0.0.WIN64.exe"><img
  alt="free zip files opener"
  title="Free download | PeaZip for Windows 64 bit"
  src="free-rar/download.png"
@@ -425,7 +425,7 @@ DOWNLOAD PEAZIP AS WINDOWS MSIX APP<br>
             <br>
             <span style="font-weight: bold;">PeaZip is also available
 as </span><a style="font-weight: bold;" target="_blank"
- href="https://github.com/giorgiotani/PeaZip/releases/download/9.0.0/PeaZip_9.0.0.0_x64__m1xx1d1szsx2y.msix">MSIX
+ href="https://github.com/giorgiotani/PeaZip/releases/download/9.9.0/PeaZip_9.0.0.0_x64__m1xx1d1szsx2y.msix">MSIX
 app for Windows 10</a><span style="font-weight: bold;">, as alternative
 to the classic exe installer which works on all Windows versions.<br>
 To install PeaZip as MSIX


### PR DESCRIPTION
the links from github probably have badly been generated   `https://github.com/peazip/PeaZip/releases/download/9.0.0/{package_name}` doesn't works   `https://github.com/peazip/PeaZip/releases/download/9.9.0/{package_name}` works **(9.9.0 tag)**   
it may affect also all other pages