### PR TITLE
Fix typo in peazip-command-line.html

### DIFF
--- a/peazip-command-line.html
+++ b/peazip-command-line.html
@@ -797,7 +797,7 @@ installer syntax examples</span></big></h3>
 /SILENT performs an unattended installation, not requiring user's
 feedback and assuming default values for all installation parameters<br>
             <br>
-/VERYSILENT performsa an unattended installation not showing the
+/VERYSILENT performs an unattended installation not showing the
 installer's UI<br>
             <br>
 /IT (example) to set application's language - also apply translation to


### PR DESCRIPTION
Simple typo fix:
performsa -> performs